### PR TITLE
Re-use existing workdir instead of generating temporary ones each run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -269,3 +269,4 @@ $RECYCLE.BIN/
 tmp
 *.tar.xz
 
+workdir


### PR DESCRIPTION
Re-use an existing workdir in `workdir/` so that repositories don't
need to be cloned every time and existing tooling will be used for
generating coverage.

Fixes: https://github.com/addaleax/node-core-coverage/issues/4
