### PR TITLE
ignoring nonexistent files

### DIFF
--- a/coverage.sh
+++ b/coverage.sh
@@ -62,7 +62,7 @@ sed -e s~"'"lib/~"'"lib_/~g -i~ node.gyp
 
 echo "Removing old coverage files" >&2
 rm -rf out/Release/.coverage
-rm out/Release/obj.target/node/src/*.gcda
+rm -f out/Release/obj.target/node/src/*.gcda
 
 echo "Building, with lib/ coverage..." >&2
 ./configure


### PR DESCRIPTION
When I try to run `./coverage` for second time I get an error because we are trying to remove `*.gcda` files from `out/Release/obj.target/node/src/` but I don't have files with that extension in that folder(I don't now if is because OS X).

<img width="593" alt="image 2016-06-05 at 12 25 13 am" src="https://cloud.githubusercontent.com/assets/6354455/15803600/16f351e2-2ab4-11e6-92a7-16d8d413f315.png">
