### PR TITLE
Compile without optimizations applied

### DIFF
--- a/patches.diff
+++ b/patches.diff
@@ -87,7 +87,7 @@ index 05a5530a2b14..fb8f865efe8a 100644
        'lib/internal/process.js',
        'lib/internal/readline.js',
        'lib/internal/repl.js',
-@@ -479,7 +480,11 @@
+@@ -479,7 +480,13 @@
          [ 'OS=="freebsd" or OS=="linux"', {
            'ldflags': [ '-Wl,-z,noexecstack',
                         '-Wl,--whole-archive <(V8_BASE)',
@@ -96,7 +96,9 @@ index 05a5530a2b14..fb8f865efe8a 100644
 +                       '--coverage',
 +                       '-g',
 +                       '-O0' ],
-+          'cflags': [ '--coverage' ]
++          'cflags': [ '--coverage',
++                      '-g',
++                      '-O0' ]
          }],
          [ 'OS=="sunos"', {
            'ldflags': [ '-Wl,-M,/usr/lib/ld/map.noexstk' ],


### PR DESCRIPTION
This should result in more accurate coverage reports.
