### PR TITLE
readme: un-mention clang as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ Node Code Coverage allow us to view the test coverage in the [Node.js Core](http
 
 ### Prerequisites
 - Bash
-- gcc and g++ 4.8 or newer, or
-- clang and clang++ 3.4 or newer
+- gcc and g++ 4.8 or newer
 - Python 2.6 or 2.7
 - GNU Make 3.81 or newer
 


### PR DESCRIPTION
clang doesn’t support gcov right now, so remove it from the README as a possible dependency.
