### PR TITLE
Fix path to node executable used for npm install

### DIFF
--- a/coverage.sh
+++ b/coverage.sh
@@ -48,7 +48,7 @@ if [ ! -x "$SRCDIR/node_modules/.bin/nyc" ] || \
   cd "$SRCDIR"
 
   # get nyc + istanbul-merge
-  ./node "$WORKDIR/node/deps/npm" install
+  "$WORKDIR/node" "$WORKDIR/node/deps/npm" install
 
   test -x "$SRCDIR/node_modules/.bin/nyc"
   test -x "$SRCDIR/node_modules/.bin/istanbul-merge"


### PR DESCRIPTION
Fixes: https://github.com/addaleax/node-core-coverage/issues/21
